### PR TITLE
fix the issue to close the screen CGM and pump config

### DIFF
--- a/FreeAPS/Sources/Modules/Base/BaseStateModel.swift
+++ b/FreeAPS/Sources/Modules/Base/BaseStateModel.swift
@@ -37,6 +37,7 @@ class BaseStateModel<Provider>: StateModel, Injectable where Provider: FreeAPS.P
 
     func hideModal() {
         router.mainModalScreen.send(nil)
+        router.mainSecondaryModalView.send(nil) 
     }
 
     func view(for screen: Screen) -> AnyView {

--- a/FreeAPS/Sources/Modules/CGM/View/CGMRootView.swift
+++ b/FreeAPS/Sources/Modules/CGM/View/CGMRootView.swift
@@ -144,8 +144,8 @@ extension CGM {
                 .background(color)
                 .onAppear(perform: configureView)
                 .navigationTitle("CGM")
-                .navigationBarTitleDisplayMode(.inline)
-//                .navigationBarItems(leading: displayClose ? Button("Close", action: state.hideModal) : nil)
+                .navigationBarTitleDisplayMode(.automatic)
+                .navigationBarItems(leading: displayClose ? Button("Close", action: state.hideModal) : nil)
                 .sheet(isPresented: $setupCGM) {
                     if let cgmFetchManager = state.cgmManager,
                        let cgmManager = cgmFetchManager.cgmManager,

--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -233,6 +233,8 @@ extension Home {
                             setupDelegate: self
                         ).asAny()
                         self.router.mainSecondaryModalView.send(view)
+                    } else if show {
+                        self.router.mainSecondaryModalView.send(self.router.view(for: .pumpConfigDirect))
                     } else {
                         self.router.mainSecondaryModalView.send(nil)
                     }

--- a/FreeAPS/Sources/Modules/PumpConfig/View/PumpConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/PumpConfig/View/PumpConfigRootView.swift
@@ -4,6 +4,7 @@ import Swinject
 extension PumpConfig {
     struct RootView: BaseView {
         let resolver: Resolver
+        let displayClose: Bool
         @StateObject var state = StateModel()
 
         @Environment(\.colorScheme) var colorScheme
@@ -54,6 +55,7 @@ extension PumpConfig {
                 .onAppear(perform: configureView)
                 .navigationTitle("Pump config")
                 .navigationBarTitleDisplayMode(.automatic)
+                .navigationBarItems(leading: displayClose ? Button("Close", action: state.hideModal) : nil)
                 .sheet(isPresented: $state.setupPump) {
                     if let pumpManager = state.provider.apsManager.pumpManager {
                         PumpSettingsView(

--- a/FreeAPS/Sources/Router/Screen.swift
+++ b/FreeAPS/Sources/Router/Screen.swift
@@ -9,6 +9,7 @@ enum Screen: Identifiable, Hashable {
     case nighscoutConfig
     case nighscoutConfigDirect
     case pumpConfig
+    case pumpConfigDirect
     case pumpSettingsEditor
     case basalProfileEditor
     case isfEditor
@@ -60,7 +61,9 @@ extension Screen {
         case .nighscoutConfigDirect:
             NightscoutConfig.RootView(resolver: resolver, displayClose: true)
         case .pumpConfig:
-            PumpConfig.RootView(resolver: resolver)
+            PumpConfig.RootView(resolver: resolver, displayClose: false)
+        case .pumpConfigDirect:
+            PumpConfig.RootView(resolver: resolver, displayClose: true)
         case .pumpSettingsEditor:
             PumpSettingsEditor.RootView(resolver: resolver)
         case .basalProfileEditor:


### PR DESCRIPTION
When opening the screen CGM config directly from the homescreen, the top menu “close / done” is not available. I use the same approach with pump config.

Updated with the same code as Trio.