### PR TITLE
fix: Bolus progress view

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -665,15 +665,14 @@ extension Home {
             }
         }
 
-        @ViewBuilder func bolusProgressView(_: GeometryProxy, _ progress: Decimal) -> some View {
+        @ViewBuilder func bolusProgressView(_: GeometryProxy, _ progress: Decimal, _ amount: Decimal) -> some View {
             let colorRectangle: Color = colorScheme == .dark ? Color(
                 "Chart"
             ) : Color.white
 
             let colorIcon = (colorScheme == .dark ? Color.white : Color.black).opacity(0.9)
 
-            let bolusTotal = state.boluses.last?.amount ?? 0
-            let bolusFraction = progress * bolusTotal
+            let bolusFraction = progress * amount
 
             let bolusString =
                 (
@@ -682,7 +681,7 @@ extension Home {
                         "0"
                 )
                 + " of " +
-                (numberFormatter.string(from: bolusTotal as NSNumber) ?? "0")
+                (numberFormatter.string(from: amount as NSNumber) ?? "0")
                 + NSLocalizedString(" U", comment: "Insulin unit")
 
             ZStack(alignment: .bottom) {
@@ -761,8 +760,8 @@ extension Home {
 
                     ZStack(alignment: .bottom) {
                         legendPanel
-                        if let progress = state.bolusProgress {
-                            bolusProgressView(geo, progress)
+                        if let progress = state.bolusProgress, let amount = state.bolusAmount {
+                            bolusProgressView(geo, progress, amount)
                         }
                     }
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,11 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-21
+  arm64-darwin-22
+  x86_64-darwin-19
+
+
 
 DEPENDENCIES
   fastlane

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,23 +2,25 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.7)
+      base64
+      nkf
       rexml
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.3.0)
-    aws-partitions (1.921.0)
-    aws-sdk-core (3.193.0)
+    aws-partitions (1.949.0)
+    aws-sdk-core (3.200.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.80.0)
-      aws-sdk-core (~> 3, >= 3.193.0)
+    aws-sdk-kms (1.87.0)
+      aws-sdk-core (~> 3, >= 3.199.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.148.0)
-      aws-sdk-core (~> 3, >= 3.193.0)
+    aws-sdk-s3 (1.155.0)
+      aws-sdk-core (~> 3, >= 3.199.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.8)
     aws-sigv4 (1.8.0)
@@ -67,7 +69,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.3.1)
-    fastlane (2.220.0)
+    fastlane (2.221.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -120,7 +122,7 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
     google-apis-iamcredentials_v1 (0.17.0)
-  google-apis-core (>= 0.11.0, < 2.a)
+      google-apis-core (>= 0.11.0, < 2.a)
     google-apis-playcustomapp_v1 (0.13.0)
       google-apis-core (>= 0.11.0, < 2.a)
     google-apis-storage_v1 (0.29.0)
@@ -146,31 +148,32 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     highline (2.0.3)
-    http-cookie (1.0.5)
+    http-cookie (1.0.6)
       domain_name (~> 0.5)
     httpclient (2.8.3)
     jmespath (1.6.2)
     json (2.7.2)
-    jwt (2.8.1)
-    base64
-    mini_magick (4.12.0)
+    jwt (2.8.2)
+      base64
+    mini_magick (4.13.1)
     mini_mime (1.1.5)
     multi_json (1.15.0)
-    multipart-post (2.4.0)
+    multipart-post (2.4.1)
     nanaimo (0.3.0)
     naturally (2.2.1)
     nkf (0.2.0)
     optparse (0.5.0)
     os (1.1.4)
     plist (3.7.1)
-    public_suffix (5.0.5)
+    public_suffix (5.1.1)
     rake (13.2.1)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.2.6)
+    rexml (3.2.9)
+      strscan
     rouge (2.0.7)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -183,6 +186,7 @@ GEM
     simctl (1.6.10)
       CFPropertyList
       naturally
+    strscan (3.1.0)
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -196,7 +200,6 @@ GEM
       unf_ext
     unf_ext (0.0.9.1)
     unicode-display_width (2.5.0)
-    webrick (1.8.1)
     word_wrap (1.0.0)
     xcodeproj (1.24.0)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -211,10 +214,7 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-22
   arm64-darwin-23
-  x86_64-darwin-19
 
 DEPENDENCIES
   fastlane


### PR DESCRIPTION
I got a bug report from multiple people using the Dana pump where the bolus progress view showed the wrong values.
Example video of the issue: https://drive.google.com/file/d/1ibcAKbN7TiByifxZj2Y2gp9ZcVxLfiMT/view?pli=1

This isn't an issue on the original iAPS repo, so I used that repo as an inspiration to fix the issue:
https://github.com/Artificial-Pancreas/iAPS/blob/main/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift#L727

![IMG_2549](https://github.com/user-attachments/assets/dc65b3f9-ead7-4c89-8296-fbc9395b6dac)

The progress view used the previous bolusAmount with the current bolusProgress. Unsure why/how DanaKit is reporting the bolus amount later than other drivers, but this is the same solution Jon is using currently

Thank you Matthias Momm & Alen Djonko for bringing this to my attention